### PR TITLE
Splitting model in seperate classes

### DIFF
--- a/python_gpt_po/services/providers/__init__.py
+++ b/python_gpt_po/services/providers/__init__.py
@@ -1,0 +1,8 @@
+"""
+Provider implementations for model management.
+"""
+from .base import ModelProviderInterface
+from .registry import ProviderRegistry
+from . import provider_init  # noqa: F401 - Auto-registers providers
+
+__all__ = ["ModelProviderInterface", "ProviderRegistry"]

--- a/python_gpt_po/services/providers/anthropic_provider.py
+++ b/python_gpt_po/services/providers/anthropic_provider.py
@@ -1,0 +1,64 @@
+"""
+Anthropic provider implementation.
+"""
+import logging
+from typing import List
+
+import requests
+
+from ...models.provider_clients import ProviderClients
+from .base import ModelProviderInterface
+
+
+class AnthropicProvider(ModelProviderInterface):
+    """Anthropic model provider implementation."""
+
+    def get_models(self, provider_clients: ProviderClients) -> List[str]:
+        """Retrieve available models from Anthropic."""
+        models = []
+
+        if not self.is_client_initialized(provider_clients):
+            logging.error("Anthropic client not initialized")
+            return models
+
+        try:
+            headers = {
+                "x-api-key": provider_clients.anthropic_client.api_key,
+                "anthropic-version": "2023-06-01"
+            }
+            response = requests.get(
+                "https://api.anthropic.com/v1/models",
+                headers=headers,
+                timeout=15
+            )
+            response.raise_for_status()
+            model_data = response.json().get("data", [])
+            models = [model["id"] for model in model_data]
+        except Exception as e:
+            logging.error("Error fetching Anthropic models: %s", str(e))
+            models = self.get_fallback_models()
+
+        return models
+
+    def get_default_model(self) -> str:
+        """Get the default Anthropic model."""
+        return "claude-3-5-haiku-latest"
+
+    def get_preferred_models(self, task: str = "translation") -> List[str]:
+        """Get preferred Anthropic models for a task."""
+        if task == "translation":
+            return ["claude-3-opus", "claude-3-5-sonnet", "claude-3-5-haiku"]
+        return ["claude-3-5-haiku-latest"]
+
+    def is_client_initialized(self, provider_clients: ProviderClients) -> bool:
+        """Check if Anthropic client is initialized."""
+        return provider_clients.anthropic_client is not None
+
+    def get_fallback_models(self) -> List[str]:
+        """Get fallback models for Anthropic."""
+        return [
+            "claude-3-7-sonnet-latest",
+            "claude-3-5-haiku-latest",
+            "claude-3-5-sonnet-latest",
+            "claude-3-opus-20240229",
+        ]

--- a/python_gpt_po/services/providers/azure_openai_provider.py
+++ b/python_gpt_po/services/providers/azure_openai_provider.py
@@ -1,0 +1,47 @@
+"""
+Azure OpenAI provider implementation.
+"""
+import logging
+from typing import List
+
+from ...models.provider_clients import ProviderClients
+from .base import ModelProviderInterface
+
+
+class AzureOpenAIProvider(ModelProviderInterface):
+    """Azure OpenAI model provider implementation."""
+
+    def get_models(self, provider_clients: ProviderClients) -> List[str]:
+        """Retrieve available models from Azure OpenAI."""
+        models = []
+
+        if not self.is_client_initialized(provider_clients):
+            logging.error("Azure OpenAI client not initialized")
+            return models
+
+        try:
+            response = provider_clients.azure_openai_client.models.list()
+            models = [model.id for model in response.data]
+        except Exception as e:
+            logging.error("Error fetching Azure OpenAI models: %s", str(e))
+            models = self.get_fallback_models()
+
+        return models
+
+    def get_default_model(self) -> str:
+        """Get the default Azure OpenAI model."""
+        return "gpt-35-turbo"
+
+    def get_preferred_models(self, task: str = "translation") -> List[str]:
+        """Get preferred Azure OpenAI models for a task."""
+        if task == "translation":
+            return ["gpt-4", "gpt-35-turbo"]
+        return ["gpt-35-turbo"]
+
+    def is_client_initialized(self, provider_clients: ProviderClients) -> bool:
+        """Check if Azure OpenAI client is initialized."""
+        return provider_clients.azure_openai_client is not None
+
+    def get_fallback_models(self) -> List[str]:
+        """Get fallback models for Azure OpenAI."""
+        return ["gpt-35-turbo", "gpt-4"]

--- a/python_gpt_po/services/providers/base.py
+++ b/python_gpt_po/services/providers/base.py
@@ -1,0 +1,60 @@
+"""
+Base interface for model providers.
+"""
+from abc import ABC, abstractmethod
+from typing import List
+
+from ...models.provider_clients import ProviderClients
+
+
+class ModelProviderInterface(ABC):
+    """Abstract base class for model providers."""
+
+    @abstractmethod
+    def get_models(self, provider_clients: ProviderClients) -> List[str]:
+        """Retrieve available models from the provider.
+
+        Args:
+            provider_clients: Initialized provider clients
+
+        Returns:
+            List of available model IDs
+        """
+
+    @abstractmethod
+    def get_default_model(self) -> str:
+        """Get the default model for this provider.
+
+        Returns:
+            Default model ID
+        """
+
+    @abstractmethod
+    def get_preferred_models(self, task: str = "translation") -> List[str]:
+        """Get preferred models for a specific task.
+
+        Args:
+            task: The task type (default: "translation")
+
+        Returns:
+            List of preferred model IDs in order of preference
+        """
+
+    @abstractmethod
+    def is_client_initialized(self, provider_clients: ProviderClients) -> bool:
+        """Check if the provider client is initialized.
+
+        Args:
+            provider_clients: Provider clients instance
+
+        Returns:
+            True if client is initialized, False otherwise
+        """
+
+    def get_fallback_models(self) -> List[str]:
+        """Get fallback models when API calls fail.
+
+        Returns:
+            List of fallback model IDs
+        """
+        return []

--- a/python_gpt_po/services/providers/deepseek_provider.py
+++ b/python_gpt_po/services/providers/deepseek_provider.py
@@ -1,0 +1,56 @@
+"""
+DeepSeek provider implementation.
+"""
+import logging
+from typing import List
+
+import requests
+
+from ...models.provider_clients import ProviderClients
+from .base import ModelProviderInterface
+
+
+class DeepSeekProvider(ModelProviderInterface):
+    """DeepSeek model provider implementation."""
+
+    def get_models(self, provider_clients: ProviderClients) -> List[str]:
+        """Retrieve available models from DeepSeek."""
+        models = []
+
+        if not self.is_client_initialized(provider_clients):
+            logging.error("DeepSeek API key not set")
+            return models
+
+        try:
+            headers = {
+                "Authorization": f"Bearer {provider_clients.deepseek_api_key}",
+                "Content-Type": "application/json"
+            }
+            response = requests.get(
+                f"{provider_clients.deepseek_base_url}/models",
+                headers=headers,
+                timeout=15
+            )
+            response.raise_for_status()
+            models = [model["id"] for model in response.json().get("data", [])]
+        except Exception as e:
+            logging.error("Error fetching DeepSeek models: %s", str(e))
+            models = self.get_fallback_models()
+
+        return models
+
+    def get_default_model(self) -> str:
+        """Get the default DeepSeek model."""
+        return "deepseek-chat"
+
+    def get_preferred_models(self, task: str = "translation") -> List[str]:
+        """Get preferred DeepSeek models for a task."""
+        return ["deepseek-chat"]
+
+    def is_client_initialized(self, provider_clients: ProviderClients) -> bool:
+        """Check if DeepSeek client is initialized."""
+        return provider_clients.deepseek_api_key is not None
+
+    def get_fallback_models(self) -> List[str]:
+        """Get fallback models for DeepSeek."""
+        return ["deepseek-chat", "deepseek-coder"]

--- a/python_gpt_po/services/providers/openai_provider.py
+++ b/python_gpt_po/services/providers/openai_provider.py
@@ -1,0 +1,53 @@
+"""
+OpenAI provider implementation.
+"""
+import logging
+from typing import List
+
+from ...models.provider_clients import ProviderClients
+from .base import ModelProviderInterface
+
+
+class OpenAIProvider(ModelProviderInterface):
+    """OpenAI model provider implementation."""
+
+    def get_models(self, provider_clients: ProviderClients) -> List[str]:
+        """Retrieve available models from OpenAI."""
+        models = []
+
+        if not self.is_client_initialized(provider_clients):
+            logging.error("OpenAI client not initialized")
+            return models
+
+        try:
+            response = provider_clients.openai_client.models.list()
+            models = [model.id for model in response.data]
+        except Exception as e:
+            logging.error("Error fetching OpenAI models: %s", str(e))
+            models = self.get_fallback_models()
+
+        return models
+
+    def get_default_model(self) -> str:
+        """Get the default OpenAI model."""
+        return "gpt-4o-mini"
+
+    def get_preferred_models(self, task: str = "translation") -> List[str]:
+        """Get preferred OpenAI models for a task."""
+        if task == "translation":
+            return ["gpt-4", "gpt-4o", "gpt-3.5-turbo"]
+        return ["gpt-4o-mini"]
+
+    def is_client_initialized(self, provider_clients: ProviderClients) -> bool:
+        """Check if OpenAI client is initialized."""
+        return provider_clients.openai_client is not None
+
+    def get_fallback_models(self) -> List[str]:
+        """Get fallback models for OpenAI."""
+        return [
+            "gpt-4o-mini",
+            "gpt-4o",
+            "gpt-4-turbo",
+            "gpt-4",
+            "gpt-3.5-turbo"
+        ]

--- a/python_gpt_po/services/providers/provider_init.py
+++ b/python_gpt_po/services/providers/provider_init.py
@@ -1,0 +1,21 @@
+"""
+Initialize and register all providers.
+"""
+from ...models.enums import ModelProvider
+from .registry import ProviderRegistry
+from .openai_provider import OpenAIProvider
+from .anthropic_provider import AnthropicProvider
+from .deepseek_provider import DeepSeekProvider
+from .azure_openai_provider import AzureOpenAIProvider
+
+
+def initialize_providers():
+    """Register all available providers."""
+    ProviderRegistry.register(ModelProvider.OPENAI, OpenAIProvider)
+    ProviderRegistry.register(ModelProvider.ANTHROPIC, AnthropicProvider)
+    ProviderRegistry.register(ModelProvider.DEEPSEEK, DeepSeekProvider)
+    ProviderRegistry.register(ModelProvider.AZURE_OPENAI, AzureOpenAIProvider)
+
+
+# Initialize providers when module is imported
+initialize_providers()

--- a/python_gpt_po/services/providers/registry.py
+++ b/python_gpt_po/services/providers/registry.py
@@ -1,0 +1,67 @@
+"""
+Registry for model providers.
+"""
+import logging
+from typing import Dict, Optional, Type
+
+from ...models.enums import ModelProvider
+from .base import ModelProviderInterface
+
+
+class ProviderRegistry:
+    """Registry to manage model provider implementations."""
+
+    _providers: Dict[ModelProvider, Type[ModelProviderInterface]] = {}
+    _instances: Dict[ModelProvider, ModelProviderInterface] = {}
+
+    @classmethod
+    def register(cls, provider: ModelProvider, provider_class: Type[ModelProviderInterface]) -> None:
+        """Register a provider implementation.
+
+        Args:
+            provider: The provider enum value
+            provider_class: The provider implementation class
+        """
+        cls._providers[provider] = provider_class
+        logging.debug("Registered provider: %s", provider.value)
+
+    @classmethod
+    def get_provider(cls, provider: ModelProvider) -> Optional[ModelProviderInterface]:
+        """Get a provider instance.
+
+        Args:
+            provider: The provider enum value
+
+        Returns:
+            Provider instance or None if not registered
+        """
+        if provider not in cls._instances:
+            provider_class = cls._providers.get(provider)
+            if provider_class:
+                cls._instances[provider] = provider_class()
+            else:
+                logging.warning("Provider %s not registered", provider.value)
+                return None
+
+        return cls._instances[provider]
+
+    @classmethod
+    def is_registered(cls, provider: ModelProvider) -> bool:
+        """Check if a provider is registered.
+
+        Args:
+            provider: The provider enum value
+
+        Returns:
+            True if registered, False otherwise
+        """
+        return provider in cls._providers
+
+    @classmethod
+    def get_all_providers(cls) -> Dict[ModelProvider, Type[ModelProviderInterface]]:
+        """Get all registered providers.
+
+        Returns:
+            Dictionary of all registered providers
+        """
+        return cls._providers.copy()


### PR DESCRIPTION
This PR refactors the model selection and handling logic by **splitting the model manager into provider-specific classes**, aiming to reduce complexity and improve modularity.

### What’s changed

* Created dedicated provider classes:

  * `openai_provider.py`
  * `azure_openai_provider.py`
  * `anthropic_provider.py`
  * `deepseek_provider.py`
* Introduced a `base.py` with a common provider interface (`BaseProvider`)
* Added a `registry.py` to dynamically resolve and initialize providers
* Updated `model_manager.py` to delegate model usage to registered provider classes instead of conditionals
* Updated all references accordingly to use the new structure

### Benefits

* Eliminates `if/else` or `match` logic for provider selection
* Makes it easier to add new providers (just implement a new class and register it)
* Improves readability, testability, and long-term maintainability
