### PR TITLE
Fixed ai tagging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ db.sqlite3
 .venv
 python_gpt_po/_version.py
 CLAUDE.md
+venv/
+test_venv/

--- a/python_gpt_po/main.py
+++ b/python_gpt_po/main.py
@@ -11,7 +11,7 @@ import traceback
 from argparse import Namespace
 from typing import Dict, List, Optional
 
-from .models.config import TranslationConfig
+from .models.config import TranslationConfig, TranslationFlags
 from .models.enums import ModelProvider
 from .models.provider_clients import ProviderClients
 from .services.model_manager import ModelManager
@@ -180,15 +180,25 @@ def main():
             logging.error(str(e))
             sys.exit(1)
 
+        # Check for deprecated --fuzzy option
+        if args.fuzzy:
+            logging.warning(
+                "WARNING: --fuzzy is DEPRECATED and has risky behavior. "
+                "Use --fix-fuzzy instead to properly translate and clean fuzzy entries."
+            )
         # Create translation configuration
+        flags = TranslationFlags(
+            bulk_mode=args.bulk,
+            fuzzy=args.fuzzy,
+            fix_fuzzy=args.fix_fuzzy,
+            folder_language=args.folder_language,
+            mark_ai_generated=not args.no_ai_comment
+        )
         config = TranslationConfig(
             provider_clients=provider_clients,
             provider=provider,
             model=model,
-            bulk_mode=args.bulk,
-            fuzzy=args.fuzzy,
-            fix_fuzzy=args.fix_fuzzy,
-            folder_language=args.folder_language
+            flags=flags
         )
 
         # Process translations

--- a/python_gpt_po/models/config.py
+++ b/python_gpt_po/models/config.py
@@ -9,12 +9,19 @@ from .provider_clients import ProviderClients
 
 
 @dataclass
+class TranslationFlags:
+    """Boolean flags for translation behavior."""
+    bulk_mode: bool = False
+    fuzzy: bool = False
+    fix_fuzzy: bool = False
+    folder_language: bool = False
+    mark_ai_generated: bool = True
+
+
+@dataclass
 class TranslationConfig:
     """Class to hold configuration parameters for the translation service."""
     provider_clients: ProviderClients
     provider: ModelProvider
     model: str
-    bulk_mode: bool = False
-    fuzzy: bool = False
-    fix_fuzzy: bool = False
-    folder_language: bool = False
+    flags: TranslationFlags

--- a/python_gpt_po/tests/test_ai_generated_tagging.py
+++ b/python_gpt_po/tests/test_ai_generated_tagging.py
@@ -1,0 +1,143 @@
+"""
+Tests for AI-generated tagging functionality.
+"""
+import tempfile
+from pathlib import Path
+
+import polib
+
+from python_gpt_po.services.po_file_handler import POFileHandler
+
+
+class TestAIGeneratedTagging:
+    """Test cases for AI-generated comment tagging."""
+
+    def test_update_po_entry_with_ai_tag(self):
+        """Test that update_po_entry adds AI-generated comment when enabled."""
+        # Create a test PO file
+        po = polib.POFile()
+        entry = polib.POEntry(msgid="Hello", msgstr="")
+        po.append(entry)
+        
+        # Update with AI tagging enabled
+        POFileHandler.update_po_entry(po, "Hello", "Bonjour", mark_ai_generated=True)
+        
+        # Check that the comment was added
+        updated_entry = po.find("Hello")
+        assert updated_entry.msgstr == "Bonjour"
+        assert updated_entry.comment == "AI-generated"
+
+    def test_update_po_entry_without_ai_tag(self):
+        """Test that update_po_entry doesn't add comment when disabled."""
+        # Create a test PO file
+        po = polib.POFile()
+        entry = polib.POEntry(msgid="Hello", msgstr="")
+        po.append(entry)
+        
+        # Update with AI tagging disabled
+        POFileHandler.update_po_entry(po, "Hello", "Bonjour", mark_ai_generated=False)
+        
+        # Check that no comment was added
+        updated_entry = po.find("Hello")
+        assert updated_entry.msgstr == "Bonjour"
+        assert not updated_entry.comment
+
+    def test_update_po_entry_preserves_existing_comment(self):
+        """Test that existing comments are preserved when adding AI tag."""
+        # Create a test PO file with existing comment
+        po = polib.POFile()
+        entry = polib.POEntry(msgid="Hello", msgstr="", comment="Existing comment")
+        po.append(entry)
+        
+        # Update with AI tagging enabled
+        POFileHandler.update_po_entry(po, "Hello", "Bonjour", mark_ai_generated=True)
+        
+        # Check that both comments are present
+        updated_entry = po.find("Hello")
+        assert updated_entry.msgstr == "Bonjour"
+        assert "Existing comment" in updated_entry.comment
+        assert "AI-generated" in updated_entry.comment
+        assert updated_entry.comment == "Existing comment\nAI-generated"
+
+    def test_update_po_entry_doesnt_duplicate_ai_tag(self):
+        """Test that AI-generated comment isn't duplicated."""
+        # Create a test PO file with existing AI-generated comment
+        po = polib.POFile()
+        entry = polib.POEntry(msgid="Hello", msgstr="Old", comment="AI-generated")
+        po.append(entry)
+        
+        # Update again with AI tagging enabled
+        POFileHandler.update_po_entry(po, "Hello", "Bonjour", mark_ai_generated=True)
+        
+        # Check that AI-generated appears only once
+        updated_entry = po.find("Hello")
+        assert updated_entry.msgstr == "Bonjour"
+        assert updated_entry.comment == "AI-generated"
+        assert updated_entry.comment.count("AI-generated") == 1
+
+    def test_get_ai_generated_entries(self):
+        """Test getting all AI-generated entries from a PO file."""
+        # Create a test PO file with mixed entries
+        po = polib.POFile()
+        po.append(polib.POEntry(msgid="Hello", msgstr="Bonjour", comment="AI-generated"))
+        po.append(polib.POEntry(msgid="World", msgstr="Monde", comment="Human translation"))
+        po.append(polib.POEntry(msgid="Test", msgstr="Test", comment="Some comment\nAI-generated"))
+        po.append(polib.POEntry(msgid="No comment", msgstr="Sans commentaire"))
+        
+        # Get AI-generated entries
+        ai_entries = POFileHandler.get_ai_generated_entries(po)
+        
+        # Check results
+        assert len(ai_entries) == 2
+        assert ai_entries[0].msgid == "Hello"
+        assert ai_entries[1].msgid == "Test"
+
+    def test_remove_ai_generated_comments(self):
+        """Test removing AI-generated comments from entries."""
+        # Create a test PO file with AI-generated comments
+        po = polib.POFile()
+        po.append(polib.POEntry(msgid="Hello", msgstr="Bonjour", comment="AI-generated"))
+        po.append(polib.POEntry(msgid="World", msgstr="Monde", comment="Human comment\nAI-generated"))
+        po.append(polib.POEntry(msgid="Test", msgstr="Test", comment="Only human comment"))
+        
+        # Remove AI-generated comments
+        POFileHandler.remove_ai_generated_comments(po)
+        
+        # Check results
+        entry1 = po.find("Hello")
+        assert entry1.comment is None
+        
+        entry2 = po.find("World")
+        assert entry2.comment == "Human comment"
+        assert "AI-generated" not in entry2.comment
+        
+        entry3 = po.find("Test")
+        assert entry3.comment == "Only human comment"
+
+    def test_po_file_persistence_with_ai_tags(self):
+        """Test that AI-generated comments persist when saving and loading PO files."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.po', delete=False) as tmp:
+            tmp_path = tmp.name
+            
+        try:
+            # Create and save a PO file with AI-generated comments
+            po = polib.POFile()
+            po.metadata = {'Language': 'fr'}
+            entry = polib.POEntry(msgid="Hello", msgstr="")
+            po.append(entry)
+            
+            # Update with AI tag
+            POFileHandler.update_po_entry(po, "Hello", "Bonjour", mark_ai_generated=True)
+            po.save(tmp_path)
+            
+            # Load the file back
+            loaded_po = polib.pofile(tmp_path)
+            loaded_entry = loaded_po.find("Hello")
+            
+            # Verify the comment persisted
+            assert loaded_entry.msgstr == "Bonjour"
+            assert loaded_entry.comment == "AI-generated"
+            
+        finally:
+            # Clean up
+            Path(tmp_path).unlink(missing_ok=True)

--- a/python_gpt_po/tests/test_django_compatibility.py
+++ b/python_gpt_po/tests/test_django_compatibility.py
@@ -1,0 +1,257 @@
+"""
+Tests for Django makemessages/compilemessages compatibility with AI-generated comments.
+"""
+import subprocess
+import tempfile
+from pathlib import Path
+
+import polib
+import pytest
+
+from python_gpt_po.services.po_file_handler import POFileHandler
+
+
+class TestDjangoCompatibility:
+    """Test cases for Django compatibility with AI-generated comments."""
+
+    def test_po_file_with_ai_comments_compiles_with_msgfmt(self):
+        """Test that PO files with AI-generated comments can be compiled with msgfmt."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.po', delete=False) as tmp:
+            # Create a PO file with AI-generated comments
+            po = polib.POFile()
+            po.metadata = {'Language': 'es', 'Content-Type': 'text/plain; charset=UTF-8'}
+            
+            # Add entries with AI-generated comments
+            entry1 = polib.POEntry(msgid="Hello", msgstr="Hola", comment="AI-generated")
+            entry2 = polib.POEntry(msgid="Welcome", msgstr="Bienvenido", comment="AI-generated")
+            entry3 = polib.POEntry(msgid="Goodbye", msgstr="Adiós")  # No AI comment
+            
+            po.append(entry1)
+            po.append(entry2)
+            po.append(entry3)
+            po.save(tmp.name)
+            
+            # Try to compile with msgfmt (what Django uses)
+            mo_file = tmp.name.replace('.po', '.mo')
+            result = subprocess.run(
+                ['msgfmt', '-o', mo_file, tmp.name],
+                capture_output=True,
+                text=True
+            )
+            
+            # Check compilation succeeded
+            assert result.returncode == 0, f"msgfmt failed: {result.stderr}"
+            assert Path(mo_file).exists()
+            assert Path(mo_file).stat().st_size > 0
+            
+            # Clean up
+            Path(tmp.name).unlink()
+            Path(mo_file).unlink()
+
+    def test_django_makemessages_removes_translator_comments(self):
+        """Test that Django makemessages removes translator comments (including AI comments)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            
+            # Create original PO file with AI comments (simulating Django structure)
+            original_po = tmppath / "django.po"
+            po_content = '''# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\\n"
+"Language: es\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+#. AI-generated
+msgid "Hello"
+msgstr "Hola"
+
+#. AI-generated
+msgid "Welcome"
+msgstr "Bienvenido"
+'''
+            original_po.write_text(po_content)
+            
+            # Verify AI comments are there
+            assert '#. AI-generated' in po_content
+            assert po_content.count('#. AI-generated') == 2
+            
+            # Create a POT template (simulating Django makemessages extraction)
+            pot_file = tmppath / "django.pot"
+            pot_content = '''# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+msgid "Hello"
+msgstr ""
+
+msgid "Welcome"
+msgstr ""
+
+msgid "New string"
+msgstr ""
+'''
+            pot_file.write_text(pot_content)
+            
+            # Run msgmerge (what Django makemessages uses internally)
+            result = subprocess.run(
+                ['msgmerge', '--quiet', '--update', '--backup=none',
+                 str(original_po), str(pot_file)],
+                capture_output=True,
+                text=True
+            )
+            
+            # Check merge succeeded
+            assert result.returncode == 0, f"msgmerge failed: {result.stderr}"
+            
+            # Read updated content
+            updated_content = original_po.read_text()
+            
+            # Verify translations are preserved but AI comments are removed
+            assert 'msgstr "Hola"' in updated_content
+            assert 'msgstr "Bienvenido"' in updated_content
+            
+            # AI comments should be gone (this is Django's behavior)
+            ai_comments_after = updated_content.count('#. AI-generated')
+            assert ai_comments_after == 0, "Django makemessages removes translator comments"
+            
+            # Load with polib to verify structure
+            merged_po = polib.pofile(str(original_po))
+            hello_entry = merged_po.find("Hello")
+            assert hello_entry.msgstr == "Hola"  # Translation preserved
+            assert not hello_entry.comment  # Comment removed
+
+    def test_django_po_format_with_ai_comments(self):
+        """Test that our AI comments work with Django-style PO files."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.po', delete=False) as tmp:
+            # Create a Django-style PO file
+            django_po_content = '''# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\\n"
+"Report-Msgid-Bugs-To: \\n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+"Language-Team: LANGUAGE <LL@li.org>\\n"
+"Language: es\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+
+#: myapp/views.py:10
+msgid "Welcome to our site"
+msgstr ""
+
+#: myapp/views.py:20
+msgid "Please login"
+msgstr ""
+'''
+            tmp.write(django_po_content)
+            tmp.flush()
+            
+            # Load with polib and add AI translations
+            po = polib.pofile(tmp.name)
+            
+            # Update entries with AI translations
+            for entry in po:
+                if entry.msgid == "Welcome to our site":
+                    POFileHandler.update_po_entry(po, entry.msgid, "Bienvenido a nuestro sitio", mark_ai_generated=True)
+                elif entry.msgid == "Please login":
+                    POFileHandler.update_po_entry(po, entry.msgid, "Por favor inicie sesión", mark_ai_generated=True)
+            
+            po.save(tmp.name)
+            
+            # Read back and verify
+            saved_content = Path(tmp.name).read_text()
+            
+            # Check that AI comments are present
+            assert '#. AI-generated' in saved_content
+            assert saved_content.count('#. AI-generated') == 2
+            
+            # Check that Django location comments are preserved
+            assert '#: myapp/views.py:10' in saved_content
+            assert '#: myapp/views.py:20' in saved_content
+            
+            # Verify the file can still be compiled
+            mo_file = tmp.name.replace('.po', '.mo')
+            result = subprocess.run(
+                ['msgfmt', '-o', mo_file, tmp.name],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            
+            # Clean up
+            Path(tmp.name).unlink()
+            Path(mo_file).unlink()
+
+    def test_mixed_translator_comments(self):
+        """Test that AI comments work alongside other translator comments."""
+        po = polib.POFile()
+        po.metadata = {'Language': 'es'}
+        
+        # Entry with existing translator comment
+        entry = polib.POEntry(
+            msgid="Dashboard",
+            msgstr="",
+            comment="Translators: Main navigation menu item"
+        )
+        po.append(entry)
+        
+        # Add AI translation
+        POFileHandler.update_po_entry(po, "Dashboard", "Tablero", mark_ai_generated=True)
+        
+        # Check both comments are present
+        updated_entry = po.find("Dashboard")
+        assert "Translators: Main navigation menu item" in updated_entry.comment
+        assert "AI-generated" in updated_entry.comment
+        assert updated_entry.msgstr == "Tablero"
+
+    @pytest.mark.skipif(
+        subprocess.run(['msgfmt', '--version'], capture_output=True).returncode != 0,
+        reason="msgfmt not available"
+    )
+    def test_gettext_tools_compatibility(self):
+        """Test compatibility with various gettext tools."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.po', delete=False) as tmp:
+            # Create PO file with AI comments
+            po = polib.POFile()
+            po.metadata = {'Language': 'es', 'Content-Type': 'text/plain; charset=UTF-8'}
+            
+            entry = polib.POEntry(msgid="Test", msgstr="Prueba", comment="AI-generated")
+            po.append(entry)
+            po.save(tmp.name)
+            
+            # Test msgfmt
+            mo_file = tmp.name.replace('.po', '.mo')
+            result = subprocess.run(['msgfmt', '-o', mo_file, tmp.name], capture_output=True)
+            assert result.returncode == 0
+            
+            # Test msgcat (concatenate and merge PO files)
+            result = subprocess.run(['msgcat', tmp.name], capture_output=True, text=True)
+            assert result.returncode == 0
+            assert '#. AI-generated' in result.stdout
+            
+            # Clean up
+            Path(tmp.name).unlink()
+            if Path(mo_file).exists():
+                Path(mo_file).unlink()

--- a/python_gpt_po/utils/cli.py
+++ b/python_gpt_po/utils/cli.py
@@ -168,12 +168,17 @@ Examples:
     fuzzy_group.add_argument(
         "--fuzzy",
         action="store_true",
-        help="Remove fuzzy markers without translating (legacy behavior, risky)"
+        help="DEPRECATED: Remove fuzzy markers without translating (risky! use --fix-fuzzy instead)"
     )
     fuzzy_group.add_argument(
         "--fix-fuzzy",
         action="store_true",
         help="Translate and clean fuzzy entries safely (recommended)"
+    )
+    advanced_group.add_argument(
+        "--no-ai-comment",
+        action="store_true",
+        help="Disable 'AI-generated' comment tagging (enabled by default for tracking)"
     )
 
     # Version information


### PR DESCRIPTION
* Added automatic tagging of AI-generated translations with `#. AI-generated`
* Introduced `--no-ai-comment` flag to disable tagging
* Deprecated `--fuzzy`; added safer `--fix-fuzzy` option
* Added docs for Azure OpenAI (CLI and Docker)
* Centralized translation flags in `TranslationFlags`
* Extended tests for AI tagging and Django compatibility
