### PR TITLE
Make --lang parameter optional with auto-detection from PO files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ pip install gpt-po-translator
 # Set API key
 export OPENAI_API_KEY='your_api_key_here'
 
-# Translate to German and French
-gpt-po-translator --folder ./locales --lang de,fr --bulk
+# Auto-detect and translate all languages
+gpt-po-translator --folder ./locales --bulk
 ```
 
 ## ✨ Key Features
@@ -73,26 +73,26 @@ export AZURE_OPENAI_API_VERSION='2024-02-01'
 
 ### Basic Translation
 ```bash
-# Translate to German (default: shows warnings/errors only)
-gpt-po-translator --folder ./locales --lang de
+# Auto-detect languages from PO files (recommended)
+gpt-po-translator --folder ./locales --bulk -v
 
-# With progress information
+# Or specify languages explicitly
+gpt-po-translator --folder ./locales --lang de,fr,es --bulk -v
+
+# Single language with progress information
 gpt-po-translator --folder ./locales --lang de -v
-
-# Multiple languages with verbose output
-gpt-po-translator --folder ./locales --lang de,fr,es -v --bulk
 ```
 
 ### Different AI Providers
 ```bash
-# Use Claude (Anthropic)
-gpt-po-translator --provider anthropic --folder ./locales --lang de
+# Use Claude (Anthropic) - auto-detect languages
+gpt-po-translator --provider anthropic --folder ./locales --bulk
 
-# Use DeepSeek
+# Use DeepSeek with specific languages
 gpt-po-translator --provider deepseek --folder ./locales --lang de
 
-# Use Azure OpenAI
-gpt-po-translator --provider azure_openai --folder ./locales --lang de
+# Use Azure OpenAI with auto-detection
+gpt-po-translator --provider azure_openai --folder ./locales --bulk
 ```
 
 ### Docker Usage
@@ -101,7 +101,7 @@ gpt-po-translator --provider azure_openai --folder ./locales --lang de
 docker run -v $(pwd):/data \
   -e OPENAI_API_KEY="your_key" \
   ghcr.io/pescheckit/python-gpt-po:latest \
-  --folder /data --lang de,fr --bulk
+  --folder /data --bulk
 
 # With Azure OpenAI
 docker run -v $(pwd):/data \

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -103,11 +103,11 @@ Below is a detailed explanation of all command-line arguments:
   *Description:* Specifies the input folder containing one or more `.po` files to be processed.  
   *Behind the scenes:* The tool recursively scans this folder and processes every file ending with `.po`.
 
-- **`--lang <language_codes>`**  
-  *Description:* A comma-separated list of ISO 639-1 language codes (e.g., `de,fr`) or locale codes (e.g., `fr_CA,pt_BR`).  
-  *Behind the scenes:* The tool filters PO files by comparing these codes with the file metadata and folder names (if `--folder-language` is enabled).
-
 ### Optional Options
+
+- **`--lang <language_codes>`** *(Optional)*  
+  *Description:* A comma-separated list of ISO 639-1 language codes (e.g., `de,fr`) or locale codes (e.g., `fr_CA,pt_BR`). **If not provided, the tool will auto-detect languages from PO file metadata or folder structure.**  
+  *Behind the scenes:* The tool filters PO files by comparing these codes with the file metadata and folder names (if `--folder-language` is enabled). When omitted, it scans all PO files to extract language information automatically.
 
 - **`--detail-lang <language_names>`**  
   *Description:* A comma-separated list of full language names (e.g., `"German,French"`) that correspond to the codes provided with `--lang`.  

--- a/python_gpt_po/main.py
+++ b/python_gpt_po/main.py
@@ -19,7 +19,7 @@ from .services.language_detector import LanguageDetector
 from .services.model_manager import ModelManager
 from .services.translation_service import TranslationService
 from .utils.cli import (auto_select_provider, create_language_mapping, get_provider_from_args, parse_args,
-                        parse_languages, show_help_and_exit, validate_provider_key)
+                        show_help_and_exit, validate_provider_key)
 
 
 def setup_logging(verbose: int = 0, quiet: bool = False):
@@ -195,18 +195,13 @@ def main():
 
         # Get languages - either from args or auto-detect from PO files
         try:
-            if args.lang:
-                languages = parse_languages(args.lang)
-                logging.info("Using specified languages: %s", ', '.join(languages))
-            else:
-                respect_gitignore = not args.no_gitignore  # Invert the flag
-                languages = LanguageDetector.detect_languages_from_folder(
-                    args.folder,
-                    use_folder_structure=args.folder_language,
-                    respect_gitignore=respect_gitignore
-                )
-                detection_method = "folder structure" if args.folder_language else "metadata"
-                logging.info("Auto-detected languages from %s: %s", detection_method, ', '.join(languages))
+            respect_gitignore = not args.no_gitignore  # Invert the flag
+            languages = LanguageDetector.validate_or_detect_languages(
+                folder=args.folder,
+                lang_arg=args.lang,
+                use_folder_structure=args.folder_language,
+                respect_gitignore=respect_gitignore
+            )
         except ValueError as e:
             logging.error(str(e))
             sys.exit(1)

--- a/python_gpt_po/utils/cli.py
+++ b/python_gpt_po/utils/cli.py
@@ -46,7 +46,10 @@ def parse_args() -> Namespace:
         description="Translate .po files using AI language models",
         epilog="""
 Examples:
-  # Basic usage with OpenAI
+  # Auto-detect languages from PO files (recommended)
+  gpt-po-translator --folder ./locales --bulk
+
+  # Specify languages explicitly
   gpt-po-translator --folder ./locales --lang fr,es,de
 
   # Use Anthropic with detailed language names
@@ -54,9 +57,6 @@ Examples:
 
   # List available models for a provider (no need for --folder or --lang)
   gpt-po-translator --provider deepseek --list-models
-
-  # Process multiple translations in bulk with a specific model
-  gpt-po-translator --folder ./locales --lang ja,ko --bulk --model gpt-4
 """,
         formatter_class=lambda prog: RawDescriptionHelpFormatter(prog, max_help_position=35, width=100)
     )
@@ -76,15 +76,14 @@ Examples:
         metavar="FOLDER",
         help="Input folder containing .po files"
     )
-    required_group.add_argument(
+
+    # Language options
+    language_group.add_argument(
         "-l", "--lang",
-        required=False,  # Now optional - will auto-detect from PO files if not provided
         metavar="LANG",
         help=("Comma-separated language codes to translate (e.g., fr,es,de or locale codes like fr_CA,pt_BR,en-US). "
               "If not provided, will auto-detect from PO files")
     )
-
-    # Language options
     language_group.add_argument(
         "--detail-lang",
         metavar="NAMES",

--- a/python_gpt_po/utils/helpers.py
+++ b/python_gpt_po/utils/helpers.py
@@ -2,8 +2,6 @@
 Helper utilities for the PO translator application.
 """
 
-from pkg_resources import DistributionNotFound, get_distribution
-
 # Import version with fallback to avoid circular imports
 try:
     from .. import __version__
@@ -21,8 +19,15 @@ def get_version():
     # First check if version is available from the top-level import
     if __version__ is not None:
         return __version__
-    # Fall back to package metadata
+
+    # Fall back to modern package metadata approach
     try:
-        return get_distribution("gpt-po-translator").version
-    except DistributionNotFound:
+        # Use importlib.metadata (Python 3.8+) or importlib_metadata (fallback)
+        try:
+            from importlib.metadata import version
+        except ImportError:
+            from importlib_metadata import version
+        return version("gpt-po-translator")
+    except Exception:
+        # Final fallback if all else fails
         return "0.0.0"


### PR DESCRIPTION
  ## Summary

  Makes the `--lang` parameter optional by implementing automatic language detection from PO file metadata and folder structure. This improves user experience by eliminating
  the need to manually specify target languages when they can be automatically determined.

  ## Changes

  ### Core Functionality
  - **Auto-detection from PO metadata**: Reads `Language` field from PO file headers
  - **Auto-detection from folder structure**: Uses `--folder-language` to detect from directory names (e.g., `locale/fr/`, `i18n/de/`)
  - **Fallback behavior**: `-l` parameter still works as override when explicit control is needed

  ### Code Changes
  - Moved `--lang` from required to optional in CLI argument parser
  - Simplified main logic to use existing `LanguageDetector.validate_or_detect_languages()` method
  - Updated help text and examples to show auto-detection as recommended approach

  ### Documentation Updates
  - Updated README.md with auto-detection examples
  - Updated docs/usage.md to reflect optional nature of `--lang`
  - Updated CLI help text with new usage patterns

  ### Bug Fixes
  - Fixed deprecated `pkg_resources` warning by migrating to `importlib.metadata`
  - Removed unused imports and fixed linting issues