### PR TITLE
Added context with msgctxt

### DIFF
--- a/python_gpt_po/tests/integration/test_real_po_files.py
+++ b/python_gpt_po/tests/integration/test_real_po_files.py
@@ -402,7 +402,7 @@ msgstr ""
         # Create a function that will track the calls to perform_translation
         detail_language_was_passed = [False]  # Use a list to make it mutable in the nested function
 
-        def mock_perform_translation(texts, target_language, is_bulk=False, detail_language=None):
+        def mock_perform_translation(texts, target_language, is_bulk=False, detail_language=None, context=None):
             if detail_language == "French":
                 detail_language_was_passed[0] = True
             return ["Bonjour", "Merci"]

--- a/python_gpt_po/tests/test_incremental_save.py
+++ b/python_gpt_po/tests/test_incremental_save.py
@@ -168,7 +168,7 @@ class TestIncrementalSave(unittest.TestCase):
         # Mock translations, but raise KeyboardInterrupt after 7 translations
         translations_done = []
 
-        def translate_with_interrupt(text, lang, detail=None):
+        def translate_with_interrupt(text, lang, detail_language=None, context=None):
             if len(translations_done) >= 7:
                 raise KeyboardInterrupt("User pressed Ctrl+C")
             result = f"Translation {len(translations_done) + 1}"
@@ -213,7 +213,7 @@ class TestIncrementalSave(unittest.TestCase):
         po_path, po_file = self.create_test_po_file(30)
 
         # Mock translations - interrupt during batch 2 (after batch 1 completes)
-        def translate_with_interrupt(texts, lang, is_bulk=False, detail_language=None):
+        def translate_with_interrupt(texts, lang, is_bulk=False, detail_language=None, context=None):
             if mock_translate.call_count == 1:
                 # First batch completes successfully
                 return [f"Translation {i+1}" for i in range(1, 11)]
@@ -283,7 +283,7 @@ class TestIncrementalSave(unittest.TestCase):
         po_path, po_file = self.create_test_po_file(10)
 
         # Mock translations with one failure
-        def translate_with_error(text, lang, detail=None):
+        def translate_with_error(text, lang, detail_language=None, context=None):
             if "string 5" in text:
                 raise Exception("API error for string 5")
             return f"Translation for {text}"
@@ -325,7 +325,7 @@ class TestIncrementalSave(unittest.TestCase):
         po_path, po_file = self.create_test_po_file(15)
 
         # Mock translations with batch 2 failing
-        def translate_with_error(texts, lang, is_bulk=False, detail_language=None):
+        def translate_with_error(texts, lang, is_bulk=False, detail_language=None, context=None):
             if mock_translate.call_count == 2:
                 raise Exception("API error for batch 2")
             return [f"Translation {i+1}" for i in range(len(texts))]

--- a/python_gpt_po/tests/test_msgctxt_support.py
+++ b/python_gpt_po/tests/test_msgctxt_support.py
@@ -1,0 +1,204 @@
+"""
+Tests for msgctxt (message context) support in translations.
+"""
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import polib
+
+from python_gpt_po.models.config import TranslationConfig, TranslationFlags
+from python_gpt_po.models.enums import ModelProvider
+from python_gpt_po.models.provider_clients import ProviderClients
+from python_gpt_po.services.translation_service import TranslationService
+
+
+class TestMsgctxtSupport:
+    """Test msgctxt context passing to AI translations."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.config = TranslationConfig(
+            provider_clients=ProviderClients(),
+            provider=ModelProvider.OPENAI,
+            model="gpt-4o-mini",
+            flags=TranslationFlags(bulk_mode=True, folder_language=False)
+        )
+        self.service = TranslationService(self.config)
+
+    def test_msgctxt_extracted_from_po_entries(self):
+        """Test that msgctxt is extracted from PO entries."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            po_file_path = Path(tmpdir) / "test.po"
+
+            # Create PO file with msgctxt
+            po = polib.POFile()
+            po.metadata = {
+                'Content-Type': 'text/plain; charset=UTF-8',
+                'Language': 'fr',
+            }
+
+            # Entry with context
+            entry1 = polib.POEntry(
+                msgctxt='button',
+                msgid='Save',
+                msgstr=''
+            )
+            po.append(entry1)
+
+            # Entry without context
+            entry2 = polib.POEntry(
+                msgid='Hello',
+                msgstr=''
+            )
+            po.append(entry2)
+
+            # Entry with different context
+            entry3 = polib.POEntry(
+                msgctxt='menu item',
+                msgid='Save',
+                msgstr=''
+            )
+            po.append(entry3)
+
+            po.save(str(po_file_path))
+
+            # Load and prepare translation request
+            po_loaded = polib.pofile(str(po_file_path))
+            request = self.service._prepare_translation_request(
+                po_loaded, str(po_file_path), 'fr', {}
+            )
+
+            # Verify contexts were extracted
+            assert len(request.contexts) == 3
+            assert request.contexts[0] == 'button'
+            assert request.contexts[1] is None
+            assert request.contexts[2] == 'menu item'
+
+    def test_msgctxt_passed_to_prompt_single_mode(self):
+        """Test that msgctxt is included in translation prompt for single mode."""
+        with patch.object(self.service, 'perform_translation', return_value='Enregistrer') as mock_translate:
+            translation = self.service.translate_single(
+                'Save',
+                'fr',
+                detail_language='French',
+                context='button'
+            )
+
+            # Verify perform_translation was called with context
+            assert mock_translate.called
+            call_args = mock_translate.call_args
+            assert call_args[1]['context'] == 'button'
+            assert translation == 'Enregistrer'
+
+    def test_msgctxt_passed_to_prompt_bulk_mode(self):
+        """Test that msgctxt is included in translation prompt for bulk mode."""
+        with patch.object(self.service, 'perform_translation', return_value=['Enregistrer', 'Annuler']) as mock_translate:
+            translations = self.service.translate_bulk(
+                ['Save', 'Cancel'],
+                'fr',
+                'test.po',
+                detail_language='French',
+                contexts=['button', 'button']
+            )
+
+            # Verify perform_translation was called with context
+            assert mock_translate.called
+            call_args = mock_translate.call_args
+            assert call_args[1]['context'] == 'button'
+            assert translations == ['Enregistrer', 'Annuler']
+
+    def test_prompt_includes_context_information(self):
+        """Test that the generated prompt includes context information."""
+        # Without context
+        prompt_no_context = TranslationService.get_translation_prompt(
+            'fr', is_bulk=False, detail_language='French', context=None
+        )
+        assert 'IMPORTANT CONTEXT' not in prompt_no_context
+
+        # With context
+        prompt_with_context = TranslationService.get_translation_prompt(
+            'fr', is_bulk=False, detail_language='French', context='button'
+        )
+        assert 'CONTEXT: button' in prompt_with_context
+        assert 'Choose the translation that matches this specific context' in prompt_with_context
+
+    def test_bulk_mode_with_mixed_contexts(self):
+        """Test bulk mode handles entries with different contexts."""
+        with patch.object(self.service, 'perform_translation', return_value=['Enregistrer', 'Sauvegarder', 'OK']) as mock_translate:
+            translations = self.service.translate_bulk(
+                ['Save', 'Save', 'OK'],
+                'fr',
+                'test.po',
+                contexts=['button', 'menu item', None]
+            )
+
+            # Should use most common context ('button' appears once, 'menu item' once, None once)
+            # In this case it would pick 'button' or 'menu item' depending on Counter
+            assert mock_translate.called
+            assert len(translations) == 3
+
+    def test_end_to_end_msgctxt_translation(self):
+        """Test full translation flow with msgctxt."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            po_file_path = Path(tmpdir) / "test.po"
+
+            # Create PO file with msgctxt
+            po = polib.POFile()
+            po.metadata = {
+                'Content-Type': 'text/plain; charset=UTF-8',
+                'Language': 'de',
+            }
+
+            entry = polib.POEntry(
+                msgctxt='button',
+                msgid='Delete',
+                msgstr=''
+            )
+            po.append(entry)
+            po.save(str(po_file_path))
+
+            # Mock the translation (return list for bulk mode)
+            with patch.object(self.service, 'perform_translation', return_value=['Löschen']) as mock_translate:
+                self.service.process_po_file(str(po_file_path), ['de'])
+
+                # Verify context was used
+                assert mock_translate.called
+                call_args = mock_translate.call_args
+                assert call_args[1].get('context') == 'button'
+
+            # Verify translation was saved
+            po_result = polib.pofile(str(po_file_path))
+            assert po_result[0].msgstr == 'Löschen'
+            assert po_result[0].msgctxt == 'button'  # Context preserved
+
+    def test_msgctxt_with_no_context_entries(self):
+        """Test that entries without msgctxt still work correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            po_file_path = Path(tmpdir) / "test.po"
+
+            po = polib.POFile()
+            po.metadata = {
+                'Content-Type': 'text/plain; charset=UTF-8',
+                'Language': 'es',
+            }
+
+            entry = polib.POEntry(
+                msgid='Hello',
+                msgstr=''
+            )
+            po.append(entry)
+            po.save(str(po_file_path))
+
+            # Mock translation (return list for bulk mode)
+            with patch.object(self.service, 'perform_translation', return_value=['Hola']) as mock_translate:
+                self.service.process_po_file(str(po_file_path), ['es'])
+
+                # Verify context was None
+                assert mock_translate.called
+                call_args = mock_translate.call_args
+                assert call_args[1].get('context') is None
+
+            # Verify translation worked
+            po_result = polib.pofile(str(po_file_path))
+            assert po_result[0].msgstr == 'Hola'


### PR DESCRIPTION
Fixed issue: https://github.com/pescheckit/python-gpt-po/issues/15

Add msgctxt support for context-aware AI translations

- Automatically extract msgctxt from PO entries
- Pass context to AI at beginning of prompt for better accuracy
- Works in both single and bulk modes
- Includes comprehensive tests